### PR TITLE
richtige unit von fertilisationStandardType?

### DIFF
--- a/src/eCH-0265-1-0.xsd
+++ b/src/eCH-0265-1-0.xsd
@@ -590,7 +590,7 @@ Datum				Version				Autor
 			</xs:element>
 			<xs:element name="correctableN" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation xml:lang="de">Stickstoff korrigierbar (N)</xs:documentation>
+					<xs:documentation xml:lang="de">Stickstoff (N) korrigierbar</xs:documentation>
 					<xs:documentation xml:lang="en">Indication whether nitrogen (N) is correctable.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -635,7 +635,7 @@ Datum				Version				Autor
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="eCH-0261:unitType">
-						<xs:enumeration value="kg/m2"/>
+						<xs:enumeration value="g/m2"/>
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>


### PR DESCRIPTION
inhaltliche Frage: <fertilisationStandardType> <unit> g/m2 oder kg/m2

im Dokument STAN_d_DRA_2023-06_21_eCH-0265_V1.0.0_Datenstandard_Agrardaten_FlächenKulturen.docx im Share > eCH-Dokumente>AG_0265_Flaechen_kulturen: Das word Dokument schreibt g/m2, das xsd hatte kg/m2.

