### PR TITLE
V2.0 Quick fixes for the pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PYTEST           := $(VENV_BIN)/pytest -p no:cacheprovider # suppress cache
 ROBOT            := java -jar $(VENV_BIN)/robot.jar
 
 # Inputs
-ONTO             := src/rdf/ontology/model.owl.ttl
+ONTO             := $(wildcard src/rdf/ontology/*.owl.ttl)
 DATA             := $(wildcard src/rdf/data/*.ttl)
 SHAPES           := src/rdf/shapes/model.shacl.ttl
 PREFIXES         := src/rdf/prefixes.ttl
@@ -114,7 +114,7 @@ $(LOG_DIR)/syntax-check.stamp: $(DATA) $(ONTO) $(SHAPES) $(PREFIXES) $(FETCHED_D
 $(MERGED_DATA): $(ONTO) $(DATA) $(FETCHED_DATA) $(PREFIXES) $(LOG_DIR)/syntax-check.stamp src/python/utils/turtle_serializer.py | $(LOG_DIR) $(VENV_BIN)/robot.jar $(VENV)/.requirements-installed.stamp
 	@echo "Merging ontology and data..."
 	@$(ROBOT) merge \
-		--input $(ONTO) \
+		$(foreach o,$(ONTO),--input $(o)) \
 		$(foreach d,$(DATA),--input $(d)) \
 		--input $(FETCHED_DATA) \
 		--input $(PREFIXES) \

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -4532,14 +4532,18 @@ cultivationtype:1246 a :CultivationType ;
         "Cucumbers 30 pcs/m2, soil culture (protected cultivation)"@en,
         "Concombres 30 pces/m2, culture en terre (culture protégée)"@fr,
         "Cetrioli 30 pz/m2, coltura in terra (coltura protetta)"@it ;
-    owl:intersectionOf ( cultivationtype:32 cultivationtype:23 ) .
+    rdfs:subClassOf [
+        owl:intersectionOf ( cultivationtype:32 cultivationtype:23 ) ;
+    ] .
 
 cultivationtype:1247 a :CultivationType ;
     schema:name "Gurken 50 Stk/m2, Erdkultur (geschützter Anbau)"@de,
         "Cucumbers 50 pcs/m2, soil culture (protected cultivation)"@en,
         "Concombres 50 pces/m2, culture en terre (culture protégée)"@fr,
         "Cetrioli 50 pz/m2, coltura in terra (coltura protetta)"@it ;
-    owl:intersectionOf ( cultivationtype:32 cultivationtype:23 ) ;
+    rdfs:subClassOf [
+        owl:intersectionOf ( cultivationtype:32 cultivationtype:23 ) ;
+    ] ;
     owl:disjointWith cultivationtype:1246 .
 
 cultivationtype:1248 a :CultivationType ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -2618,7 +2618,7 @@ cultivationtype:602 a :CultivationType ;
     schema:description "Übrige Kunstwiese, beitragsberechtigt (z.B. Schweineweide, Geflügelweide)"@de,
         "Autres prairies artificielles donnant droit aux contributions (p.ex. pâturages pour porcs et volaille)"@fr,
         "Altri prati artificiali avente diritto ai contributi (p.es. pascoli riservati ai suini e al pollame)"@it ;
-    rdfs:subClassOf cultivationtype:601 .
+    rdfs:subClassOf cultivationtype:1 .
 
 cultivationtype:611 a :CultivationType ;
     schema:name "Extensiv genutzte Wiesen (ohne Weiden)"@de,


### PR DESCRIPTION
## Changes

- Consider all RDF files in `src/rdf/ontology/` in the Makefile.
- Un-declare cultivationtype:602 as a subclass of cultivationtype:601, as the two are disjoint.
- Temporarily declare `cultivationtype:1246` and `cultivationtype:1247` as subclasses of an anonymous class which in turn is the intersection of two classes --> fixes a logical error.