### PR TITLE
42 remodelling of ackerflaeche

### DIFF
--- a/src/rdf/data/srppp.ttl
+++ b/src/rdf/data/srppp.ttl
@@ -2059,7 +2059,7 @@ psm:27 a :PlantProtectionCrop  ;
         "grande culture en général"@fr,
         "Campicoltura in generale"@it ;
     schema:version 0 ;
-    :cultivationType cultivationtype:1 .
+    :cultivationType cultivationtype:1022 .
 
 psm:270 a :PlantProtectionCrop  ;
     schema:identifier "46D3C073-CBD8-4B3A-A9AA-21785BA911CA" ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -181,6 +181,7 @@ cultivationtype:22 a :CultivationType ;
     owl:unionOf (
         cultivationtype:23
         cultivationtype:24
+        cultivationtype:540
     ) .
 
 cultivationtype:23 a :CultivationType ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -47,7 +47,7 @@ cultivationtype:1 a :CultivationType ;
         "Domaine app. grande culture"@fr,
         "Grande culture en général"@fr ;
     schema:description "Umfasst Flächen, die im Rahmen der Fruchtfolge für den Anbau von einjährigen oder temporären Kulturen genutzt werden."@de ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:464 .
 
 cultivationtype:2 a :CultivationType ;
     schema:name "Dauerwiesen"@de,
@@ -173,7 +173,7 @@ cultivationtype:21 a :CultivationType ;
     schema:name "Dauergrünfläche"@de ;
     schema:alternateName "Dauergrünland"@de ;
     schema:description "Als Dauergrünfläche gilt die mit Gräsern und Kräutern bewachsene Fläche ausserhalb der Sömmerungsflächen. Sie besteht seit mehr als sechs Jahren als Dauerwiese oder als Dauerweide (Art. 19 LBV)."@de ;
-    rdfs:subClassOf cultivationtype:114 .
+    rdfs:subClassOf cultivationtype:114, cultivationtype:464 .
 
 cultivationtype:22 a :CultivationType ;
     schema:name "Gemüsebau"@de,
@@ -1877,7 +1877,7 @@ cultivationtype:466 a :CultivationType ;
 
 cultivationtype:467 a :CultivationType ;
     schema:name "Dauerkulturen"@de ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:464 .
 
 cultivationtype:468 a :CultivationType ;
     schema:name "Ackerbohne"@de,

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -627,7 +627,7 @@ cultivationtype:114 a :CultivationType ;
     schema:name "Grünfläche"@de,
         "surfaces herbagères"@fr,
         "Superficie inerbita"@it ;
-    rdfs:subClassOf :Cultivation .
+    rdfs:subClassOf cultivationtype:464 .
 
 cultivationtype:115 a :CultivationType ;
     schema:name "Brassica napus-Rüben"@de,
@@ -2312,7 +2312,7 @@ cultivationtype:545 a :CultivationType ;
     schema:name "Einjährige Freilandgemüse, ohne Konservengemüse"@de,
         "Cultures maraîchères de plein champ annuelles (sauf les légumes de conserve)"@fr,
         "Ortaggi annuali di pieno campo (esclusi quelli destinati alla conservazione)"@it ;
-    rdfs:subClassOf cultivationtype:24, cultivationtype:465 .
+    rdfs:subClassOf cultivationtype:24, cultivationtype:465, cultivationtype:910 .
 
 cultivationtype:546 a :CultivationType ;
     schema:name "Freiland-Konservengemüse"@de,
@@ -3431,7 +3431,7 @@ cultivationtype:1022 a :CultivationType ;
     schema:name "Feldbau"@de,
         "Grande culture"@fr,
         "Campicoltura"@it ;
-    schema:alternateName "Allg. Feldbau"@de ,
+    schema:alternateName "Allg. Feldbau"@de ;
     rdfs:subClassOf cultivationtype:910 .
 
 cultivationtype:1023 a :CultivationType ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -2578,7 +2578,7 @@ cultivationtype:594 a :CultivationType ;
     schema:description "Beitragsberechtigte offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Terres ouvertes donnant droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Superficie coltiva aperta, avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 ;
+    rdfs:subClassOf cultivationtype:910 ;
     :managementIntensity intensity:Extensive .
 
 cultivationtype:595 a :CultivationType ;
@@ -2588,20 +2588,20 @@ cultivationtype:595 a :CultivationType ;
     schema:description "Nicht beitragsberechtigte übrige offene Ackerfläche (regionsspezifische Biodiversitätsförderfläche)"@de,
         "Autres terres ouvertes ne donnant pas droit aux contributions (surfaces de promotion de la biodiversité spécifiques à la région)"@fr,
         "Altra superficie coltiva aperta, non avente diritto ai contributi (superfici per la promozione della biodiversità specifiche di una regione)"@it ;
-    rdfs:subClassOf cultivationtype:1 ;
+    rdfs:subClassOf cultivationtype:910 ;
     :managementIntensity intensity:Extensive .
 
 cultivationtype:597 a :CultivationType ;
     schema:name "Beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes avec contributions"@fr,
         "Altra superficie coltiva aperta, con contributi"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:910 .
 
 cultivationtype:598 a :CultivationType ;
     schema:name "Nicht beitragsberechtigte übrige offene Ackerfläche"@de,
         "Autres terres ouvertes sans contributions"@fr,
         "Altra superficie coltiva aperta, senza contributi"@it ;
-    rdfs:subClassOf cultivationtype:1 .
+    rdfs:subClassOf cultivationtype:910 .
 
 cultivationtype:601 a :CultivationType ;
     schema:name "Kunstwiesen (ohne Weiden)"@de,
@@ -3184,6 +3184,12 @@ cultivationtype:909 a :CultivationType ;
         "Giardini e orti domestici"@it ;
     rdfs:subClassOf cultivationtype:12 .
 
+cultivationtype:910 a :CultivationType ;
+    schema:name "Offene Ackerfläche"@de,
+        "Terres ouvertes"@fr,
+        "Superficie coltiva aperta"@it ;
+    rdfs:subClassOf cultivationtype:1 .
+
 cultivationtype:911 a :CultivationType ;
     schema:name "Landwirtschaftliche Produktion in Gebäuden (z. B. Champignon, Brüsseler)"@de,
         "Production agricole sous abri (par ex. champignons de Paris, chicorée witloof)"@fr,
@@ -3421,6 +3427,12 @@ cultivationtype:1021 a :CultivationType ;
     schema:name "Winterkorn, Dinkel"@de ;
     rdfs:subClassOf cultivationtype:19,
         cultivationtype:516 .
+
+cultivationtype:1022 a :CultivationType ;
+    schema:name "Feldbau"@de,
+        "Grande culture"@fr,
+        "Campicoltura"@it ;
+    rdfs:subClassOf cultivationtype:910 .
 
 cultivationtype:1023 a :CultivationType ;
     schema:name "Nützlingsstreifen (DK)"@de ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -41,8 +41,7 @@ cultivationtype:1 a :CultivationType ;
     schema:name "Ackerfläche"@de,
         "Terres cultivées"@fr,
         "Superficie coltiva"@it ;
-    schema:alternateName "Allg. Feldbau"@de ,
-        "Ackerkulturen"@de,
+    schema:alternateName "Ackerkulturen"@de,
         "Ackerbau"@de,
         "Domaine app. grande culture"@fr,
         "Grande culture en général"@fr ;
@@ -3432,6 +3431,7 @@ cultivationtype:1022 a :CultivationType ;
     schema:name "Feldbau"@de,
         "Grande culture"@fr,
         "Campicoltura"@it ;
+    schema:alternateName "Allg. Feldbau"@de ,
     rdfs:subClassOf cultivationtype:910 .
 
 cultivationtype:1023 a :CultivationType ;

--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -177,7 +177,7 @@ cultivationtype:21 a :CultivationType ;
 cultivationtype:22 a :CultivationType ;
     schema:name "Gemüsebau"@de,
         "Vegetable Production"@en ;
-    rdfs:subClassOf :Cultivation ;
+    rdfs:subClassOf cultivationtype:464 ;
     owl:unionOf (
         cultivationtype:23
         cultivationtype:24


### PR DESCRIPTION
Remodelling of the Ackerflächen hierarchy according to [whiteboard](https://blw-ofag-ufag.atlassian.net/wiki/spaces/BID/whiteboard/1784315993?atl_f=PAGETREE)

- Reparented Ackerfläche (1), Dauerkulturen (467), and Grünfläche (114) under LN (464).  
- Introduced Offene Ackerfläche (910) for AGIS leaf nodes and created a parallel Feldbau (1022) class to correctly map psm:27.  
- Linked `cultivationtype:545` to Offene Ackerfläche while keeping the Gemüsebau root independent.  

Closes #42

This issue does not address the topic of crops which should now be remodelled under Feldbau (new issue --> #406)

Bonus: (temporary) fix for chickpeas #59 