### PR TITLE
Improve mapping table processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ONTO             := $(wildcard src/rdf/ontology/*.owl.ttl)
 DATA             := $(wildcard src/rdf/data/*.ttl)
 SHAPES           := src/rdf/shapes/model.shacl.ttl
 PREFIXES         := src/rdf/prefixes.ttl
-QUERIES          := $(wildcard src/sparql/processing/*.rq)
+QUERIES          := $(sort $(wildcard src/sparql/processing/*.rq))
 PIPELINE_SCRIPTS := $(sort $(wildcard src/python/pipeline/*.py))
 
 # Intermediate & Output Files

--- a/src/sparql/processing/02_mapping_table_skos_generation.rq
+++ b/src/sparql/processing/02_mapping_table_skos_generation.rq
@@ -1,10 +1,6 @@
 # DESCRIPTION:
 # This SPARQL update query cross-references agricultural crop observation sets
-# across different systems (AGIS, NAEBI, PSMV) and materializes their semantic 
-# relationships directly into the graph.
-# It evaluates the class hierarchy using rdfs:subClassOf paths to infer 
-# structural mappings and writes them using SKOS vocabulary (exactMatch, 
-# broadMatch, narrowMatch).
+# across different systems and materializes their relationships according to SKOS.
 
 PREFIX cube: <https://cube.link/>
 PREFIX : <https://agriculture.ld.admin.ch/crops/>

--- a/src/sparql/processing/02_mapping_table_skos_generation.rq
+++ b/src/sparql/processing/02_mapping_table_skos_generation.rq
@@ -1,4 +1,3 @@
-# DESCRIPTION:
 # This SPARQL update query cross-references agricultural crop observation sets
 # across different systems and materializes their relationships according to SKOS.
 
@@ -7,51 +6,41 @@ PREFIX : <https://agriculture.ld.admin.ch/crops/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-# 1. EXACT MATCHES (Identical cultivation types)
+# 1. EXACT MATCH
 INSERT {
   ?obsS skos:exactMatch ?obsT .
 }
 WHERE {
   ?setS cube:observation ?obsS .
-  ?setT a cube:ObservationSet ;
-        cube:observation ?obsT .
+  ?setT cube:observation ?obsT .
   FILTER(?setS != ?setT)
-  
   ?obsS :cultivationType/^:cultivationType ?obsT .
 };
 
-# 2. BROAD MATCHES (Target system is more general)
+# 2. BROAD MATCH
 INSERT {
   ?obsS skos:broadMatch ?obsT .
 }
 WHERE {
   ?setS cube:observation ?obsS .
-  ?setT a cube:ObservationSet ;
-        cube:observation ?obsT .
+  ?setT cube:observation ?obsT .
   FILTER(?setS != ?setT)
-  
-  ?obsS :cultivationType ?typeS .
-  ?obsT :cultivationType ?typeT .
-  
-  ?typeS rdfs:subClassOf+ ?typeT .
-  # Condition: Target system does not have an exact match for the source
-  FILTER NOT EXISTS { ?setT cube:observation [ :cultivationType ?typeS ] }
+  ?obsS :cultivationType / rdfs:subClassOf+ / ^:cultivationType ?obsT .
+  FILTER NOT EXISTS { 
+    ?obsS skos:exactMatch / ^cube:observation ?setT . 
+  }
 };
 
-# 3. NARROW MATCHES (Target system is more specific)
+# 3. NARROW MATCH
 INSERT {
   ?obsS skos:narrowMatch ?obsT .
 }
 WHERE {
   ?setS cube:observation ?obsS .
-  ?setT a cube:ObservationSet ;
-        cube:observation ?obsT .
+  ?setT cube:observation ?obsT .
   FILTER(?setS != ?setT)
-  
-  ?obsS :cultivationType ?typeS .
-  ?obsT :cultivationType ?typeT .
-  
-  ?typeT rdfs:subClassOf+ ?typeS .
-  # Condition: Target system does not have an exact match for the source
-  FILTER NOT EXISTS { ?setT cube:observation [ :cultivationType ?typeS ] }
+  ?obsS :cultivationType / ^rdfs:subClassOf+ / ^:cultivationType ?obsT .
+  FILTER NOT EXISTS { 
+    ?obsS (skos:exactMatch|skos:broadMatch) / ^cube:observation ?setT .
+  }
 };

--- a/src/sparql/processing/02_mapping_table_skos_generation.rq
+++ b/src/sparql/processing/02_mapping_table_skos_generation.rq
@@ -8,39 +8,39 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 # 1. EXACT MATCH
 INSERT {
-  ?obsS skos:exactMatch ?obsT .
+  ?s skos:exactMatch ?t .
 }
 WHERE {
-  ?setS cube:observation ?obsS .
-  ?setT cube:observation ?obsT .
-  FILTER(?setS != ?setT)
-  ?obsS :cultivationType/^:cultivationType ?obsT .
+  ?s_set cube:observation ?s .
+  ?t_set cube:observation ?t .
+  FILTER(?s_set != ?t_set)
+  ?s :cultivationType/^:cultivationType ?t .
 };
 
 # 2. BROAD MATCH
 INSERT {
-  ?obsS skos:broadMatch ?obsT .
+  ?s skos:broadMatch ?t .
 }
 WHERE {
-  ?setS cube:observation ?obsS .
-  ?setT cube:observation ?obsT .
-  FILTER(?setS != ?setT)
-  ?obsS :cultivationType / rdfs:subClassOf+ / ^:cultivationType ?obsT .
+  ?s_set cube:observation ?s .
+  ?t_set cube:observation ?t .
+  FILTER(?s_set != ?t_set)
+  ?s :cultivationType / rdfs:subClassOf+ / ^:cultivationType ?t .
   FILTER NOT EXISTS { 
-    ?obsS skos:exactMatch / ^cube:observation ?setT . 
+    ?s skos:exactMatch / ^cube:observation ?t_set . 
   }
 };
 
 # 3. NARROW MATCH
 INSERT {
-  ?obsS skos:narrowMatch ?obsT .
+  ?s skos:narrowMatch ?t .
 }
 WHERE {
-  ?setS cube:observation ?obsS .
-  ?setT cube:observation ?obsT .
-  FILTER(?setS != ?setT)
-  ?obsS :cultivationType / ^rdfs:subClassOf+ / ^:cultivationType ?obsT .
+  ?s_set cube:observation ?s .
+  ?t_set cube:observation ?t .
+  FILTER(?s_set != ?t_set)
+  ?s :cultivationType / ^rdfs:subClassOf+ / ^:cultivationType ?t .
   FILTER NOT EXISTS { 
-    ?obsS (skos:exactMatch|skos:broadMatch) / ^cube:observation ?setT .
+    ?s (skos:exactMatch|skos:broadMatch) / ^cube:observation ?t_set .
   }
 };

--- a/src/sparql/queries/mapping_table.rq
+++ b/src/sparql/queries/mapping_table.rq
@@ -1,0 +1,15 @@
+# Generate a mapping table that can be easily understood and used
+# by downstream data consumers.
+PREFIX : <https://agriculture.ld.admin.ch/crops/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX schema: <http://schema.org/>
+SELECT ?s ?s_name ?p ?o ?o_name
+FROM <https://lindas.admin.ch/foag/ech/0265/2>
+WHERE {
+    ?s ?p ?o .
+    VALUES ?p { skos:narrowMatch skos:exactMatch skos:broadMatch }
+    ?s schema:name ?s_name .
+    ?o schema:name ?o_name .
+    FILTER(LANG(?s_name)="de" && LANG(?o_name)="de")
+}
+ORDER BY ?s ?o

--- a/src/sparql/queries/test.rq
+++ b/src/sparql/queries/test.rq
@@ -1,6 +1,0 @@
-# Get the first 10 triples
-SELECT *
-WHERE { 
-    ?s ?p ?o .
-}
-LIMIT 10


### PR DESCRIPTION
## Changes

- Add a query that generates the actual mapping table from the materialized triples.
- Removed `test.rq` (this file was just set up in the template to test the pipeline).
- Adjust the mapping generation SPARQL update query:
  - Aggressive use of property paths to keep statements short.
  - Rely on previously inserted triples to filter out statements
  - Rename variables (just my personal preference to quickly spot the important variables ?s and ?t)
  - Filter out more cases in step 3 by matching both `skos:exactMatch` *OR* `skos:broadMatch` (before, essentially only `skos:exactMatch` was matched).
- Update `Makefile` in order to make sure to process the SPARQL update queries in alphabetical filename order.