### PR TITLE
fix #330

### DIFF
--- a/src/rdf/ontology/cultivationtypes.owl.ttl
+++ b/src/rdf/ontology/cultivationtypes.owl.ttl
@@ -3820,7 +3820,7 @@ cultivationtype:1097 a :CultivationType ;
     schema:name "Himbeer-Jungpflanzen (Long-Cane)"@de,
         "Jeunes plants de framboisiers (Long-Cane)"@fr,
         "Giovani piante di lampone (Long-Cane)"@it ;
-    rdfs:subClassOf cultivationtype:723 .
+    rdfs:subClassOf cultivationtype:471 .
 
 cultivationtype:1098 a :CultivationType ;
     schema:name "Blaue Malve"@de,


### PR DESCRIPTION
according to the SB Wegleitung "Himbeeren-Jungpflanzen (Long-Cane)" belong to Beeren (same group as "Himbeeren, 1.5 kg/m2" which we also categorized as subclasses of Beerenbau). Therefore, I thought that it's more consistent to also add them to Beerenbau instead of "Baumschulen von Obst und Beeren" (`cultivationtype:723`).

closes #330