### PR TITLE
Minor changes/restructuring of mapping table chapter

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -31,6 +31,8 @@ format:
     toc: true
     number-sections: true
     embed-resources: true
+    syntax-definitions:
+     - assets/sparql.xml
   gfm: 
     toc: false
     number-sections: false
@@ -41,3 +43,5 @@ format:
     link-citations: true
   typst:
     number-sections: true
+    syntax-definitions:
+     - assets/sparql.xml

--- a/docs/assets/sparql.xml
+++ b/docs/assets/sparql.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language>
+<language name="SPARQL" section="Database" version="1" kateversion="5.0"
+    extensions="*.rq;*.sparql"
+    mimetype="application/sparql-query"
+    author="Damian Oswald (damian.oswald@protonmail.com)"
+    license="MIT">
+  <highlighting>
+    <list name="keywords">
+      <item>ADD</item>
+      <item>AS</item>
+      <item>ASC</item>
+      <item>ASK</item>
+      <item>BASE</item>
+      <item>BIND</item>
+      <item>BY</item>
+      <item>CLEAR</item>
+      <item>CONSTRUCT</item>
+      <item>COPY</item>
+      <item>CREATE</item>
+      <item>DATA</item>
+      <item>DEFAULT</item>
+      <item>DELETE</item>
+      <item>DESC</item>
+      <item>DESCRIBE</item>
+      <item>DISTINCT</item>
+      <item>DROP</item>
+      <item>EXISTS</item>
+      <item>FILTER</item>
+      <item>FROM</item>
+      <item>GRAPH</item>
+      <item>GROUP</item>
+      <item>HAVING</item>
+      <item>IN</item>
+      <item>INSERT</item>
+      <item>INTO</item>
+      <item>LIMIT</item>
+      <item>LOAD</item>
+      <item>MINUS</item>
+      <item>MOVE</item>
+      <item>NAMED</item>
+      <item>NOT</item>
+      <item>OFFSET</item>
+      <item>OPTIONAL</item>
+      <item>ORDER</item>
+      <item>PREFIX</item>
+      <item>REDUCED</item>
+      <item>SELECT</item>
+      <item>SERVICE</item>
+      <item>SILENT</item>
+      <item>TO</item>
+      <item>UNDEF</item>
+      <item>UNION</item>
+      <item>USING</item>
+      <item>VALUES</item>
+      <item>WHERE</item>
+      <item>WITH</item>
+    </list>
+    <list name="functions">
+      <item>ABS</item>
+      <item>BNODE</item>
+      <item>BOUND</item>
+      <item>CEIL</item>
+      <item>COALESCE</item>
+      <item>CONCAT</item>
+      <item>CONTAINS</item>
+      <item>DATATYPE</item>
+      <item>DAY</item>
+      <item>ENCODE_FOR_URI</item>
+      <item>FLOOR</item>
+      <item>HOURS</item>
+      <item>IF</item>
+      <item>IRI</item>
+      <item>ISBLANK</item>
+      <item>ISIRI</item>
+      <item>ISLITERAL</item>
+      <item>ISNUMERIC</item>
+      <item>ISURI</item>
+      <item>LANG</item>
+      <item>LANGMATCHES</item>
+      <item>LCASE</item>
+      <item>MD5</item>
+      <item>MINUTES</item>
+      <item>MONTH</item>
+      <item>NOW</item>
+      <item>RAND</item>
+      <item>REGEX</item>
+      <item>REPLACE</item>
+      <item>ROUND</item>
+      <item>SAMETERM</item>
+      <item>SECONDS</item>
+      <item>SHA1</item>
+      <item>SHA256</item>
+      <item>SHA384</item>
+      <item>SHA512</item>
+      <item>STR</item>
+      <item>STRAFTER</item>
+      <item>STRBEFORE</item>
+      <item>STRDT</item>
+      <item>STRENDS</item>
+      <item>STRLANG</item>
+      <item>STRLEN</item>
+      <item>STRSTARTS</item>
+      <item>STRUUID</item>
+      <item>SUBSTR</item>
+      <item>TIMEZONE</item>
+      <item>TZ</item>
+      <item>UCASE</item>
+      <item>URI</item>
+      <item>UUID</item>
+      <item>YEAR</item>
+    </list>
+    <list name="aggregates">
+      <item>AVG</item>
+      <item>COUNT</item>
+      <item>GROUP_CONCAT</item>
+      <item>MAX</item>
+      <item>MIN</item>
+      <item>SAMPLE</item>
+      <item>SUM</item>
+    </list>
+    <contexts>
+      <context name="Normal" attribute="Normal Text" lineEndContext="#stay">
+        <DetectSpaces/>
+        <DetectChar attribute="Comment" context="Singleline Comment" char="#"/>
+        <RangeDetect attribute="IRI" context="#stay" char="&lt;" char1="&gt;"/>
+        <StringDetect attribute="String" context="StringTSS" String="'''"/>
+        <StringDetect attribute="String" context="StringTDS" String="&quot;&quot;&quot;"/>
+        <DetectChar attribute="String" context="StringS" char="'"/>
+        <DetectChar attribute="String" context="StringD" char="&quot;"/>
+        <HlCHex attribute="Hex" context="#stay"/>
+        <Float attribute="Float" context="#stay"/>
+        <Int attribute="Decimal" context="#stay"/>
+        <StringDetect attribute="Variable" context="#stay" String="[\?\$]\w+"/>
+        <keyword attribute="Keyword" String="keywords" context="#stay" insensitive="true"/>
+        <keyword attribute="Function" String="functions" context="#stay" insensitive="true"/>
+        <keyword attribute="Function" String="aggregates" context="#stay" insensitive="true"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="&amp;" char1="&amp;"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="|" char1="|"/>
+        <Detect2Chars attribute="Operator" context="#stay" char="!" char1="="/>
+        <Detect2Chars attribute="Operator" context="#stay" char="&lt;" char1="="/>
+        <Detect2Chars attribute="Operator" context="#stay" char="&gt;" char1="="/>
+        <Detect2Chars attribute="Operator" context="#stay" char="^" char1="^"/>
+        <AnyChar attribute="Operator" context="#stay" String="*+-/=!&lt;&gt;()[]{},;.|^"/>
+        <StringDetect attribute="Boolean" context="#stay" String="\b(true|false)\b" insensitive="true"/>
+        <StringDetect attribute="Prefixed Name" context="#stay" String="\b[a-zA-Z0-9_.-]*:[a-zA-Z0-9_.-]+"/>
+        <StringDetect attribute="Blank Node" context="#stay" String="_:[a-zA-Z0-9_.-]+"/>
+        <StringDetect attribute="LangTag" context="#stay" String="@[a-zA-Z]+(-[a-zA-Z0-9]+)*"/>
+      </context>
+      <context name="StringS" attribute="String" lineEndContext="#stay">
+        <HlCStringChar attribute="String Char" context="#stay"/>
+        <DetectChar attribute="String" context="#pop" char="'"/>
+      </context>
+      <context name="StringD" attribute="String" lineEndContext="#stay">
+        <HlCStringChar attribute="String Char" context="#stay"/>
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
+      <context name="StringTSS" attribute="String" lineEndContext="#stay">
+        <StringDetect attribute="String" context="#pop" String="'''"/>
+      </context>
+      <context name="StringTDS" attribute="String" lineEndContext="#stay">
+        <StringDetect attribute="String" context="#pop" String="&quot;&quot;&quot;"/>
+      </context>
+      <context name="Singleline Comment" attribute="Comment" lineEndContext="#pop">
+        <IncludeRules context="##Comments"/>
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal Text"   defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Keyword"       defStyleNum="dsKeyword" spellChecking="false"/>
+      <itemData name="Function"      defStyleNum="dsFunction" spellChecking="false"/>
+      <itemData name="Decimal"       defStyleNum="dsDecVal" spellChecking="false"/>
+      <itemData name="Hex"           defStyleNum="dsBaseN" spellChecking="false"/>
+      <itemData name="Float"         defStyleNum="dsFloat" spellChecking="false"/>
+      <itemData name="String"        defStyleNum="dsString"/>
+      <itemData name="String Char"   defStyleNum="dsChar" spellChecking="false"/>
+      <itemData name="Comment"       defStyleNum="dsComment"/>
+      <itemData name="Operator"      defStyleNum="dsOperator" spellChecking="false"/>
+      <itemData name="Variable"      defStyleNum="dsOthers" spellChecking="false" bold="1"/>
+      <itemData name="IRI"           defStyleNum="dsString" spellChecking="false"/>
+      <itemData name="Prefixed Name" defStyleNum="dsDataType" spellChecking="false"/>
+      <itemData name="Blank Node"    defStyleNum="dsOthers" spellChecking="false"/>
+      <itemData name="LangTag"       defStyleNum="dsDataType" spellChecking="false"/>
+      <itemData name="Boolean"       defStyleNum="dsConstant" spellChecking="false"/>
+    </itemDatas>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="#" />
+    </comments>
+    <keywords casesensitive="0" />
+  </general>
+</language>

--- a/docs/de/index.qmd
+++ b/docs/de/index.qmd
@@ -169,7 +169,7 @@ TBC.
 
 # Instruktionen zur Datenintegration
 
-Die diesem Dokument zugrundeliegenden Master- und Referenzdaten als _Linked Data_ verfügbar.
+Die diesem Dokument zugrundeliegenden Master- und Referenzdaten sind als _Linked Data_ verfügbar.
 
 Die technologische Basis dafür bildet das [Resource Description Framework (RDF)](https://www.w3.org/TR/rdf11-concepts/), ein zentraler Standard des World Wide Web Consortiums (W3C) zur Modellierung von Datenstrukturen im Web.
 In RDF werden Informationen nicht in klassischen Tabellen, sondern als vernetzte Graphen abgebildet.
@@ -184,7 +184,7 @@ Das folgende Kapitel gibt eine minimale Anleitung, wie die Daten von LINDAS abge
 ## Bezug der Stammdaten über LINDAS {#sec-lindas-data-integration}
 
 Die Kulturenstammdaten können als Linked Data mittels der Abfragesprache [SPARQL 1.1 Query Language](https://www.w3.org/TR/sparql11-query/) direkt aus dem LINDAS-Triplestore bezogen werden.
-Das nachfolgende generische Beispiel zeigt eine einfache Abfrage, welche sämtliche Nutzungstypen mit deren Deutschem Namen zurückgibt:
+Das nachfolgende generische Beispiel zeigt eine einfache Abfrage, welche sämtliche Nutzungstypen mit deren deutschem Namen zurückgibt:
 
 ``` rq
 {{< include ../../src/sparql/queries/example.rq >}}
@@ -206,7 +206,8 @@ curl -X POST "https://lindas.admin.ch/query" \
 ```
 
 Dieser Aufruf setzt voraus, dass eine gültige SPARQL-Abfrage in der lokalen Datei `query.rq` vorliegt.
-Je nach Anforderung lässt sich das Rückgabeformat über den `Accept`-Header steuern. Für `SELECT`-Abfragen unterstützt LINDAS standardmässig strukturierte Formate wie JSON (`application/sparql-results+json`), XML (`application/sparql-results+xml`) CSV (`text/csv`).
+Je nach Anforderung lässt sich das Rückgabeformat über den `Accept`-Header steuern.
+Für `SELECT`-Abfragen unterstützt LINDAS standardmässig strukturierte Formate wie JSON (`application/sparql-results+json`), XML (`application/sparql-results+xml`) und CSV (`text/csv`).
 
 ## Bezug von Mapping-Tabellen {#sec-mapping-tables}
 

--- a/docs/de/index.qmd
+++ b/docs/de/index.qmd
@@ -212,9 +212,9 @@ Je nach Anforderung lässt sich das Rückgabeformat über den `Accept`-Header st
 
 Um die Beziehungen zwischen den Kulturen der unterschiedlichen Systeme aufzuzeigen, werden Mapping-Tabellen bereitgestellt. Diese dienen als «Übersetzung» zwischen dem Direktzahlungssystem (AGIS), dem Nährstoffbilanz-Berechnungsservice (NAEBI) und dem Pflanzenschutzmittelverzeichnis (PSM). 
 
-Die Relationen der Kulturen zueinander werden durch semantische Beziehungen des *Simple Knowledge Organization System* (SKOS) klassifiziert:
+Die Relationen der Kulturen zueinander werden durch Beziehungen des *Simple Knowledge Organization System* (SKOS) klassifiziert:
 
-- `skos:exactMatch`: Verknüpft zwei Konzepte (d.h. Kulturen aus zwei Systemen) bei denen ein hohes Mass an Sicherheit besteht, dass sie synonym verwendet werden können.
+- `skos:exactMatch`: Verknüpft zwei Konzepte (d.h. Kulturen aus zwei Systemen) bei denen genau dasselbe gemeint ist.
 - `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Beziehungen zueinander invers sind.
 
 | Quellsystem | Kultur Quellsystem | SKOS-Beziehung | Zielsystem | Kultur Zielsystem | Anmerkung |

--- a/docs/de/index.qmd
+++ b/docs/de/index.qmd
@@ -217,7 +217,7 @@ Die Relationen der Kulturen zueinander werden durch semantische Prädikate des *
 - `skos:exactMatch`: Verknüpft zwei Konzepte (d.h. Kulturen aus zwei Systemen) bei denen ein hohes Mass an Sicherheit besteht, dass sie synonym verwendet werden können.
 - `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Prädikate zueinander invers sind.
 
-| Quellsystem | Kultur Quellsystem | SKOS-Prädikat | Zielsystem | Kultur Zielsystem | Semantische Beziehung |
+| Quellsystem | Kultur Quellsystem | SKOS-Beziehung | Zielsystem | Kultur Zielsystem | Anmerkung |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | AGIS | Sommergerste | `skos:exactMatch` | NAEBI | Sommergerste | Die Kulturen im Quell- und Zielsystem sind synonym. |
 | AGIS | Wintergerste | `skos:narrowMatch` | NAEBI | Wintergerste in 62a Nitrat-Projekt | Die Kultur im Zielsystem ist spezifischer als jene im Quellsystem. |

--- a/docs/de/index.qmd
+++ b/docs/de/index.qmd
@@ -212,10 +212,10 @@ Je nach Anforderung lässt sich das Rückgabeformat über den `Accept`-Header st
 
 Um die Beziehungen zwischen den Kulturen der unterschiedlichen Systeme aufzuzeigen, werden Mapping-Tabellen bereitgestellt. Diese dienen als «Übersetzung» zwischen dem Direktzahlungssystem (AGIS), dem Nährstoffbilanz-Berechnungsservice (NAEBI) und dem Pflanzenschutzmittelverzeichnis (PSM). 
 
-Die Relationen der Kulturen zueinander werden durch semantische Prädikate des *Simple Knowledge Organization System* (SKOS) klassifiziert:
+Die Relationen der Kulturen zueinander werden durch semantische Beziehungen des *Simple Knowledge Organization System* (SKOS) klassifiziert:
 
 - `skos:exactMatch`: Verknüpft zwei Konzepte (d.h. Kulturen aus zwei Systemen) bei denen ein hohes Mass an Sicherheit besteht, dass sie synonym verwendet werden können.
-- `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Prädikate zueinander invers sind.
+- `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Beziehungen zueinander invers sind.
 
 | Quellsystem | Kultur Quellsystem | SKOS-Beziehung | Zielsystem | Kultur Zielsystem | Anmerkung |
 | :--- | :--- | :--- | :--- | :--- | :--- |

--- a/docs/de/index.qmd
+++ b/docs/de/index.qmd
@@ -151,7 +151,7 @@ Die korrekte Nachbildung dieser Polyhierarchie ist in den Daten folglich essenzi
 
 # Datenmodell
 
-## Nutzung von Semantic-Web-Technologien
+## Nutzung von Semantic-Web-Technologien {#sec-linked-data}
 
 Im Gegensatz zum Pflanzenschutzmittelverzeichnis wird beim Nährstoffbilanzrechner Mais als Getreide gezählt – es existieren also verschiedene Definitionen von Getreide.
 Um diese eindeutig kennzeichnen zu können, setzen wir auf Linked Data.
@@ -167,10 +167,46 @@ TBC.
 
 {{< include entities.md >}}
 
-# Nutzung der Daten
+# Instruktionen zur Datenintegration
 
-- Sämtliche hier beschriebenen Daten können auf LINDAS bezogen werden.
-- Knappe Anleitung zum Beziehen der Daten.
+Die diesem Dokument zugrundeliegenden Master- und Referenzdaten als _Linked Data_ verfügbar.
+
+Die technologische Basis dafür bildet das [Resource Description Framework (RDF)](https://www.w3.org/TR/rdf11-concepts/), ein zentraler Standard des World Wide Web Consortiums (W3C) zur Modellierung von Datenstrukturen im Web.
+In RDF werden Informationen nicht in klassischen Tabellen, sondern als vernetzte Graphen abgebildet.
+Jede Aussage besteht dabei aus einem sogenannten Triple (Subjekt, Prädikat, Objekt).
+Diese Struktur ermöglicht eine maschinenlesbare, interoperable und systemübergreifend eindeutige Beschreibung von Ressourcen und deren Relationen zueinander.
+
+Für die Speicherung und Publikation dieser RDF-Daten wird [LINDAS](https://lindas.admin.ch/) (Linked Data Service) genutzt, der offizielle Linked-Data-Dienst der Schweizer Bundesverwaltung.
+LINDAS fungiert als sogenannter _Triple Store_, einer spezialisierte Graphdatenbank, die für das effiziente Speichern und Abfragen von RDF-Triples optimiert ist und die Daten öffentlich über eine genormte Schnittstelle bereitstellt.
+
+Das folgende Kapitel gibt eine minimale Anleitung, wie die Daten von LINDAS abgefragt und bezogen werden können.
+
+## Bezug der Stammdaten über LINDAS {#sec-lindas-data-integration}
+
+Die Kulturenstammdaten können als Linked Data mittels der Abfragesprache [SPARQL 1.1 Query Language](https://www.w3.org/TR/sparql11-query/) direkt aus dem LINDAS-Triplestore bezogen werden.
+Das nachfolgende generische Beispiel zeigt eine einfache Abfrage, welche sämtliche Nutzungstypen mit deren Deutschem Namen zurückgibt:
+
+``` rq
+{{< include ../../src/sparql/queries/example.rq >}}
+```
+
+Auf <https://lindas.admin.ch/sparql/> können solche Abfragen manuell über eine graphische Benutzeroberfläche ausgeführt werden.
+
+Weitere praxisnahe Abfragebeispiele stehen im [GitHub Repository unter src/sparql/queries](https://github.com/blw-ofag-ufag/eCH-0265/tree/main/src/sparql/queries) zur Verfügung.
+
+Für den automatisierten Datenabruf und die Systemintegration kann der LINDAS-Endpunkt über einen HTTP-POST-Request angesprochen werden.
+Dabei wird die SPARQL-Abfrage direkt im Body der Anfrage übermittelt.
+Ein entsprechendes Aufrufbeispiel mit `curl` sieht folgendermassen aus:
+
+``` sh
+curl -X POST "https://lindas.admin.ch/query" \
+     -H "Content-Type: application/sparql-query" \
+     -H "Accept: application/sparql-results+json" \
+     --data-binary @query.rq -o data.json
+```
+
+Dieser Aufruf setzt voraus, dass eine gültige SPARQL-Abfrage in der lokalen Datei `query.rq` vorliegt.
+Je nach Anforderung lässt sich das Rückgabeformat über den `Accept`-Header steuern. Für `SELECT`-Abfragen unterstützt LINDAS standardmässig strukturierte Formate wie JSON (`application/sparql-results+json`), XML (`application/sparql-results+xml`) CSV (`text/csv`).
 
 ## Bezug von Mapping-Tabellen {#sec-mapping-tables}
 
@@ -179,9 +215,7 @@ Um die Beziehungen zwischen den Kulturen der unterschiedlichen Systeme aufzuzeig
 Die Relationen der Kulturen zueinander werden durch semantische Prädikate des *Simple Knowledge Organization System* (SKOS) klassifiziert:
 
 - `skos:exactMatch`: Verknüpft zwei Konzepte (d.h. Kulturen aus zwei Systemen) bei denen ein hohes Mass an Sicherheit besteht, dass sie synonym verwendet werden können.
-- `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Prädikate zueinander invers sind. 
-
-**Beispiele der Mapping-Relationen:**
+- `skos:narrowMatch` und `skos:broadMatch`: Beschreiben eine hierarchische Zuordnung zwischen zwei Konzepten, wobei die beiden Prädikate zueinander invers sind.
 
 | Quellsystem | Kultur Quellsystem | SKOS-Prädikat | Zielsystem | Kultur Zielsystem | Semantische Beziehung |
 | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -189,31 +223,17 @@ Die Relationen der Kulturen zueinander werden durch semantische Prädikate des *
 | AGIS | Wintergerste | `skos:narrowMatch` | NAEBI | Wintergerste in 62a Nitrat-Projekt | Die Kultur im Zielsystem ist spezifischer als jene im Quellsystem. |
 | AGIS | Emmer, Einkorn | `skos:broadMatch` | PSM | Getreide | Die Kultur im Quellsystem ist spezifischer als jene im Zielsystem. |
 
-### Integration der Kulturbeziehungen in den Graphen
+: Beispiele der Mapping-Relationen {#tbl-mapping-example}
 
-Die Prädikate `skos:exactMatch`, `skos:narrowMatch` und `skos:broadMatch` werden im Verarbeitungsprozess direkt an die Kulturen im Graphen angehängt und sind auf LINDAS abfragbar. Die Generierung erfolgt über das SPARQL-Skript `src/sparql/processing/02_mapping_table_skos_generation.rq` mittels `INSERT`-Befehlen. 
+Die Prädikate `skos:exactMatch`, `skos:narrowMatch` und `skos:broadMatch` werden im Verarbeitungsprozess direkt an die Kulturen im Graphen angehängt und sind auf LINDAS abfragbar. Die Generierung erfolgt über das SPARQL-Skript `src/sparql/processing/02_mapping_table_skos_generation.rq` mittels `INSERT`-Befehlen.
 
-*Hinweis:* Im Datenverarbeitungsprozess werden hierarchische Prädikate (`narrowMatch`, `broadMatch`) nur dann generiert, wenn für eine Kultur aus einem Quellsystem nicht bereits ein `skos:exactMatch` im jeweiligen Zielsystem gefunden wurde. Dies verhindert redundante synonyme und hierarchische Beziehungen für dieselbe Kultur und fördert die Übersichtlichkeit der resultierenden Mapping-Tabelle.
+::: {.callout-note}
+Im Datenverarbeitungsprozess werden hierarchische Prädikate (`narrowMatch`, `broadMatch`) nur dann generiert, wenn für eine Kultur aus einem Quellsystem nicht bereits ein `skos:exactMatch` im jeweiligen Zielsystem gefunden wurde. Dies verhindert redundante synonyme und hierarchische Beziehungen für dieselbe Kultur und fördert die Übersichtlichkeit der resultierenden Mapping-Tabelle.
+:::
 
-### Abfrage der Mapping-Tabelle über LINDAS
+Eine vorbereitete SPARQL-Abfrage zur Generierung der vollständigen Mapping-Tabelle (AGIS, NAEBI und PSM) befindet sich [im eCH-0265 Repository unter `src/sparql/queries/mapping_table.rq`](https://github.com/blw-ofag-ufag/eCH-0265/blob/main/src/sparql/queries/mapping_table.rq). 
 
-Eine vorbereitete SPARQL-Abfrage zur Generierung der vollständigen Mapping-Tabelle (AGIS, NAEBI und PSM) befindet sich im eCH-0265 Repository unter `src/sparql/queries/mapping_table.rq`. 
-
-Diese Abfrage kann direkt in der Benutzeroberfläche von [LINDAS](https://lindas.admin.ch/sparql/) ausgeführt und als CSV oder JSON exportiert werden. Alternativ lässt sich die Tabelle programmatisch via `curl` beziehen. Im lokalen Repository kann die Mapping-Tabelle mit dem folgenden Befehl heruntergeladen werden:
-
-```bash
-# CSV Download
-curl -X POST -H "Accept: text/csv" \
-     -H "Content-Type: application/sparql-query" \
-     --data-binary @src/sparql/queries/mapping_table.rq \
-     https://lindas.admin.ch/sparql
-
-# JSON Download
-curl -X POST -H "Accept: application/json" \
-     -H "Content-Type: application/sparql-query" \
-     --data-binary @src/sparql/queries/mapping_table.rq \
-     https://lindas.admin.ch/sparql
-```
+Diese Abfrage kann direkt in der Benutzeroberfläche von [LINDAS](https://lindas.admin.ch/sparql/) ausgeführt und als CSV oder JSON exportiert werden. Alternativ lässt sich die Tabelle programmatisch beziehen, siehe @sec-lindas-data-integration.
 
 # Sicherheitsaspekte
 

--- a/src/sparql/queries/example.rq
+++ b/src/sparql/queries/example.rq
@@ -1,0 +1,11 @@
+# Table of all cultivation types and their German name
+PREFIX : <https://agriculture.ld.admin.ch/crops/>
+PREFIX schema: <http://schema.org/>
+SELECT *
+FROM <https://lindas.admin.ch/foag/ech/0265/2>
+WHERE {
+  ?crop a :CultivationType ;
+    schema:name ?name .
+  FILTER(LANG(?name) = "de")
+}
+ORDER BY ?name


### PR DESCRIPTION
## Summary

- Added XML file + quarto references for SPARQL syntax highlighting
- Added example SPARQL query as a `.rq` file that is embedded in the Quarto document. This means the query is automatically tested by the testing pipeline.
- Separated the sections about data fetching from LINDAS from the mapping table generation.
- Minor updates in the text.